### PR TITLE
Add seqmeta metadata inspection toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,77 @@
 # whats-up-doc
-Please write me a python script/tool which will take a pair of fastq files R1 and R2 and subsample the fastq files and suggest details surrounding the posisble source tissue, the organism(s) sequenced, the library prep methods, the sequencing platform and any other useful deriveable info.
+
+`seqmeta` is a small toolkit for extracting informative metadata from FASTQ files
+referenced by a simple tab-separated sample sheet. It inspects the sequencing
+headers and read content to produce a JSON report that summarises attributes
+useful for downstream analysis and quality control such as the likely organism,
+sequencing platform, indexing scheme, library preparation hints and read quality
+metrics.
+
+## Features
+
+* Parses sample sheets with ``sample_id`` and R1/R2 FASTQ file paths.
+* Supports plain or gzip-compressed FASTQ files (detected automatically by
+  reading the file magic bytes).
+* Samples the first N reads of each file (configurable) and reports:
+  * Read length distribution, GC content, N content and mean/median quality
+    scores.
+  * Flowcell, lane and instrument information parsed from Illumina-style
+    headers with heuristic mapping to the sequencing platform.
+  * Index sequences and whether single or dual indexing is present.
+  * Adapter contamination estimates for a curated catalogue of common library
+    kits.
+  * Keyword-based guesses for organism, tissue/source, library type and
+    enrichment strategy using both the sample identifier and observed adapters.
+  * Simple quality warnings (e.g., low average quality or excessive adapter
+    signal).
+
+The heuristics are intentionally conservative and designed to provide guidance
+rather than definitive answers. They can be extended easily by editing
+``seqmeta/constants.py``.
+
+## Installation
+
+The project is packaged as a standard Python module. Install it into a virtual
+environment or use it directly via ``python -m``:
+
+```bash
+pip install .
+```
+
+## Usage
+
+Create a tab-separated sample sheet with the following format:
+
+```text
+sample_id\t/path/to/sample_R1.fastq.gz\t/path/to/sample_R2.fastq.gz
+```
+
+The second column is mandatory; provide the third column when a paired-end file
+is available. Paths may be relative to the location of the sample sheet.
+
+Run the CLI on the sample sheet to produce a JSON report:
+
+```bash
+seqmeta path/to/samples.tsv --max-reads 75000 --pretty --output metadata.json
+```
+
+* ``--max-reads`` controls how many reads are sampled from each FASTQ file (the
+  default is 50,000).
+* ``--pretty`` toggles human-readable JSON indentation.
+* ``--output`` writes the report to a file instead of printing to stdout.
+
+## Development
+
+This repository includes a pytest suite that exercises the sample sheet parser,
+core analyser and CLI. After making changes run:
+
+```bash
+pip install -e .[test]
+pytest
+```
+
+(The tests dynamically construct their own FASTQ fixtures, so there is no large data bundle tracked in version control.)
+
+## License
+
+MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "seqmeta"
+version = "0.1.0"
+description = "FASTQ metadata extraction toolkit"
+readme = "README.md"
+authors = [{name = "ChatGPT"}]
+license = {text = "MIT"}
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[project.scripts]
+seqmeta = "seqmeta.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/seqmeta/__init__.py
+++ b/src/seqmeta/__init__.py
@@ -1,0 +1,4 @@
+"""seqmeta package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/src/seqmeta/analysis.py
+++ b/src/seqmeta/analysis.py
@@ -1,0 +1,301 @@
+"""Core routines for extracting metadata from FASTQ files."""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .inference import (
+    classify_index_type,
+    detect_umi_from_headers,
+    infer_enrichments,
+    infer_library_types,
+    infer_organisms,
+    infer_tissues,
+    instrument_to_platform,
+    summarise_adapter_hits,
+)
+from .constants import ADAPTER_SEQUENCES
+from .io import read_fastq
+from .samplesheet import SampleEntry
+
+
+@dataclass
+class ReadStats:
+    """Container accumulating summary statistics for a FASTQ file."""
+
+    read_count: int = 0
+    total_bases: int = 0
+    gc_bases: int = 0
+    lengths: List[int] = field(default_factory=list)
+    read_mean_qualities: List[float] = field(default_factory=list)
+    min_length: Optional[int] = None
+    max_length: Optional[int] = None
+    min_read_mean_quality: Optional[float] = None
+    max_read_mean_quality: Optional[float] = None
+    sum_quality_scores: int = 0
+    base_counts: Counter = field(default_factory=Counter)
+    cycle_quality_sums: List[float] = field(default_factory=list)
+    cycle_quality_counts: List[int] = field(default_factory=list)
+    headers_sampled: List[str] = field(default_factory=list)
+    index_sequences: Counter = field(default_factory=Counter)
+    adapter_hits: Counter = field(default_factory=Counter)
+    first_header_info: Optional[Dict[str, str]] = None
+
+    def add_read(self, header: str, sequence: str, quality: str) -> None:
+        sequence = sequence.strip()
+        quality = quality.strip()
+        if len(sequence) == 0:
+            return
+        if len(sequence) != len(quality):
+            # Skip malformed records.
+            return
+
+        length = len(sequence)
+        self.read_count += 1
+        self.total_bases += length
+        self.lengths.append(length)
+        self.min_length = length if self.min_length is None else min(self.min_length, length)
+        self.max_length = length if self.max_length is None else max(self.max_length, length)
+
+        seq_upper = sequence.upper()
+        self.base_counts.update(seq_upper)
+        self.gc_bases += sum(1 for base in seq_upper if base in {"G", "C"})
+
+        scores = [ord(char) - 33 for char in quality]
+        mean_quality = sum(scores) / length if length else 0.0
+        self.read_mean_qualities.append(mean_quality)
+        self.sum_quality_scores += sum(scores)
+        self.min_read_mean_quality = (
+            mean_quality
+            if self.min_read_mean_quality is None
+            else min(self.min_read_mean_quality, mean_quality)
+        )
+        self.max_read_mean_quality = (
+            mean_quality
+            if self.max_read_mean_quality is None
+            else max(self.max_read_mean_quality, mean_quality)
+        )
+
+        if len(self.cycle_quality_sums) < length:
+            extend_by = length - len(self.cycle_quality_sums)
+            self.cycle_quality_sums.extend([0.0] * extend_by)
+            self.cycle_quality_counts.extend([0] * extend_by)
+        for idx, score in enumerate(scores):
+            self.cycle_quality_sums[idx] += score
+            self.cycle_quality_counts[idx] += 1
+
+        if len(self.headers_sampled) < 100:
+            self.headers_sampled.append(header)
+
+        header_info = parse_read_header(header)
+        if self.first_header_info is None:
+            self.first_header_info = header_info
+
+        index_sequence = header_info.get("index_sequence")
+        if index_sequence:
+            self.index_sequences[index_sequence] += 1
+
+        for adapter_name, adapter_seq in ADAPTER_SEQUENCES.items():
+            if adapter_seq and adapter_seq in seq_upper:
+                self.adapter_hits[adapter_name] += 1
+
+    def gc_fraction(self) -> Optional[float]:
+        if self.total_bases == 0:
+            return None
+        return self.gc_bases / self.total_bases
+
+    def mean_quality(self) -> Optional[float]:
+        if self.total_bases == 0:
+            return None
+        return self.sum_quality_scores / self.total_bases
+
+    def summary(self) -> Dict[str, object]:
+        if self.read_count == 0:
+            return {
+                "read_count": 0,
+                "average_length": 0,
+                "median_length": 0,
+                "gc_fraction": None,
+            }
+        average_length = self.total_bases / self.read_count if self.read_count else 0
+        gc_fraction = self.gc_fraction()
+        n_bases = self.base_counts.get("N", 0)
+        n_fraction = n_bases / self.total_bases if self.total_bases else 0.0
+        per_cycle_quality = []
+        for total, count in zip(self.cycle_quality_sums, self.cycle_quality_counts):
+            per_cycle_quality.append(total / count if count else math.nan)
+        return {
+            "read_count": self.read_count,
+            "average_length": average_length,
+            "median_length": statistics.median(self.lengths) if self.lengths else 0,
+            "length_range": [self.min_length, self.max_length],
+            "gc_fraction": gc_fraction,
+            "n_fraction": n_fraction,
+            "base_composition": dict(self.base_counts),
+            "quality": {
+                "mean_phred": self.mean_quality(),
+                "median_read_mean_phred": statistics.median(self.read_mean_qualities)
+                if self.read_mean_qualities
+                else None,
+                "min_read_mean_phred": self.min_read_mean_quality,
+                "max_read_mean_phred": self.max_read_mean_quality,
+                "per_cycle_mean": per_cycle_quality,
+            },
+            "index_sequences": self.index_sequences.most_common(10),
+            "adapter_hits": dict(self.adapter_hits),
+            "header_examples": self.headers_sampled[:5],
+            "first_header": self.first_header_info,
+        }
+
+
+def parse_read_header(header: str) -> Dict[str, str]:
+    header = header.strip()
+    if header.startswith("@"):
+        header = header[1:]
+    parts = header.split(" ", 1)
+    first_part = parts[0]
+    second_part = parts[1] if len(parts) > 1 else ""
+    data: Dict[str, str] = {}
+    tokens = first_part.split(":")
+    if len(tokens) >= 4:
+        data["instrument"] = tokens[0]
+        data["run_number"] = tokens[1]
+        data["flowcell_id"] = tokens[2]
+        data["lane"] = tokens[3]
+    if len(tokens) >= 5:
+        data["tile"] = tokens[4]
+    if len(tokens) >= 6:
+        data["x_pos"] = tokens[5]
+    if len(tokens) >= 7:
+        data["y_pos"] = tokens[6]
+
+    if second_part:
+        second_tokens = second_part.split(":")
+        if len(second_tokens) >= 1:
+            data["read"] = second_tokens[0]
+        if len(second_tokens) >= 2:
+            data["is_filtered"] = second_tokens[1]
+        if len(second_tokens) >= 3:
+            data["control_number"] = second_tokens[2]
+        if len(second_tokens) >= 4:
+            data["index_sequence"] = second_tokens[3]
+    return data
+
+
+def collect_read_statistics(path: Path, max_reads: int) -> ReadStats:
+    stats = ReadStats()
+    for header, sequence, quality in read_fastq(path, max_reads=max_reads):
+        stats.add_read(header, sequence, quality)
+    return stats
+
+
+def _combine_counters(counters: Iterable[Counter]) -> Counter:
+    combined = Counter()
+    for counter in counters:
+        combined.update(counter)
+    return combined
+
+
+def _aggregate_headers(stats_list: Iterable[ReadStats]) -> List[str]:
+    headers: List[str] = []
+    for stats in stats_list:
+        headers.extend(stats.headers_sampled)
+    return headers
+
+
+def analyze_sample(entry: SampleEntry, max_reads: int = 50000) -> Dict[str, object]:
+    """Inspect FASTQ files for ``entry`` and return metadata."""
+
+    r1_stats = collect_read_statistics(entry.r1_path, max_reads=max_reads)
+    r2_stats = collect_read_statistics(entry.r2_path, max_reads=max_reads) if entry.r2_path else None
+
+    stats_list = [r1_stats] + ([r2_stats] if r2_stats else [])
+    total_sampled_reads = sum(stats.read_count for stats in stats_list)
+
+    combined_index_counter = _combine_counters(stats.index_sequences for stats in stats_list)
+    combined_adapter_counter = _combine_counters(stats.adapter_hits for stats in stats_list)
+
+    gc_fraction_values = [stats.gc_fraction() for stats in stats_list if stats.gc_fraction() is not None]
+    gc_fraction = sum(gc_fraction_values) / len(gc_fraction_values) if gc_fraction_values else None
+
+    instrument = r1_stats.first_header_info.get("instrument") if r1_stats.first_header_info else None
+    flowcell_id = r1_stats.first_header_info.get("flowcell_id") if r1_stats.first_header_info else None
+    run_number = r1_stats.first_header_info.get("run_number") if r1_stats.first_header_info else None
+    lane = r1_stats.first_header_info.get("lane") if r1_stats.first_header_info else None
+
+    platform = instrument_to_platform(instrument)
+
+    adapter_summary = summarise_adapter_hits(combined_adapter_counter)
+    adapter_names = [item["adapter"] for item in adapter_summary]
+    top_adapter_fraction = 0.0
+    if combined_adapter_counter and total_sampled_reads:
+        top_adapter_fraction = (
+            combined_adapter_counter.most_common(1)[0][1] / total_sampled_reads
+        )
+
+    organism_info = infer_organisms(entry.sample_id, gc_fraction)
+    tissues = infer_tissues(entry.sample_id)
+    library_types = infer_library_types(entry.sample_id, adapter_names)
+    enrichments = infer_enrichments(entry.sample_id)
+    index_type = classify_index_type(combined_index_counter.keys())
+    umi_present = detect_umi_from_headers(_aggregate_headers(stats_list))
+
+    r1_summary = r1_stats.summary()
+
+    read_metrics = {
+        "r1": r1_summary,
+        "r2": r2_stats.summary() if r2_stats else None,
+    }
+
+    sequencing_run = {
+        "instrument": instrument,
+        "platform": platform,
+        "flowcell_id": flowcell_id,
+        "run_number": run_number,
+        "lane": lane,
+        "index_type": index_type,
+        "index_sequences": combined_index_counter.most_common(10),
+        "umi_in_headers": umi_present,
+    }
+
+    library = {
+        "adapter_hits": adapter_summary,
+        "library_type_guesses": library_types,
+        "enrichment_guesses": enrichments,
+        "adapter_hit_rate": top_adapter_fraction,
+    }
+
+    warnings: List[str] = []
+    primary_quality = r1_stats.mean_quality()
+    if primary_quality is not None and primary_quality < 25:
+        warnings.append("Mean R1 quality score is below Q25")
+    if top_adapter_fraction > 0.2:
+        warnings.append(
+            "Adapter sequence present in more than 20% of sampled reads (consider trimming)"
+        )
+    if r1_summary["n_fraction"] > 0.05:
+        warnings.append("More than 5% ambiguous bases in R1 reads")
+
+    metadata = {
+        "sample_id": entry.sample_id,
+        "files": {
+            "r1": str(entry.r1_path),
+            "r2": str(entry.r2_path) if entry.r2_path else None,
+        },
+        "paired_end": entry.r2_path is not None,
+        "sequencing_run": sequencing_run,
+        "library": library,
+        "organism": organism_info,
+        "tissue_guesses": tissues,
+        "read_metrics": read_metrics,
+        "warnings": warnings,
+    }
+    return metadata
+
+
+__all__ = ["analyze_sample", "collect_read_statistics", "parse_read_header", "ReadStats"]

--- a/src/seqmeta/cli.py
+++ b/src/seqmeta/cli.py
@@ -1,0 +1,74 @@
+"""Command line interface for the seqmeta toolkit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .analysis import analyze_sample
+from .samplesheet import SampleSheet
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect FASTQ files referenced by a simple tab-separated sample sheet "
+            "and extract sequencing metadata."
+        )
+    )
+    parser.add_argument("samplesheet", type=Path, help="Path to the sample sheet (TSV)")
+    parser.add_argument(
+        "--max-reads",
+        type=int,
+        default=50000,
+        help=(
+            "Maximum number of reads to sample from each FASTQ file."
+            " Larger values increase accuracy at the cost of runtime."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional location to write the JSON report (defaults to stdout)",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON with indentation for easier inspection",
+    )
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Skip verification that FASTQ files referenced in the sample sheet exist",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    sheet = SampleSheet.from_file(args.samplesheet, validate_paths=not args.no_validate)
+
+    results: List[Dict[str, Any]] = []
+    for entry in sheet:
+        metadata = analyze_sample(entry, max_reads=args.max_reads)
+        results.append(metadata)
+
+    report = {"samples": results}
+    indent = 2 if args.pretty or args.output else None
+    output_text = json.dumps(report, indent=indent)
+
+    if args.output:
+        args.output.write_text(output_text + "\n", encoding="utf-8")
+    else:
+        sys.stdout.write(output_text)
+        if not output_text.endswith("\n"):
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/seqmeta/constants.py
+++ b/src/seqmeta/constants.py
@@ -1,0 +1,109 @@
+"""Reference data used by the heuristic inference engine."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+# Illumina adapter sequences compiled from vendor documentation and common kits.
+ADAPTER_SEQUENCES = OrderedDict(
+    [
+        ("TruSeq Universal Adapter", "AGATCGGAAGAG"),
+        ("TruSeq LT Adapter", "AGATCGGAAGAGCACACGTCT"),
+        ("Nextera Transposase Adapter", "CTGTCTCTTATACACATCT"),
+        ("Nextera Read 2", "CTGTCTCTTATACACATCTGACGCTGCCGACGA"),
+        ("Nextera Read 1", "TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG"),
+        ("NEBNext Universal Adapter", "AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC"),
+        ("Ion Torrent Adapter A", "CCATCTCATCCCTGCGTGTCTCCGACTCAG"),
+        ("Ion Torrent Adapter P1", "CCTCTCTATGGGCAGTCGGTGAT"),
+        ("Swift Accel-NGS", "GTTCAGAGTTCTACAGTCCGACGATC"),
+    ]
+)
+
+# Keywords describing common organisms. Values are ordered to allow deterministic output.
+ORGANISM_KEYWORDS = OrderedDict(
+    [
+        ("Homo sapiens", ["human", "homo", "hg19", "hg38", "grch", "hs" ]),
+        ("Mus musculus", ["mouse", "mm", "mus", "grcm", "mm10"]),
+        ("Rattus norvegicus", ["rat", "rn" ]),
+        ("Danio rerio", ["zebrafish", "dr", "danio"]),
+        ("Drosophila melanogaster", ["dros", "dm", "fruitfly"]),
+        ("Arabidopsis thaliana", ["arabidopsis", "at"]),
+        ("Saccharomyces cerevisiae", ["yeast", "sc", "s288c"]),
+        ("Escherichia coli", ["ecoli", "e.coli", "mg1655", "ec" ]),
+        ("Mycobacterium tuberculosis", ["mtb", "h37rv", "mycobacter" ]),
+        ("Plasmodium falciparum", ["plasmodium", "pfal", "pf3d7"]),
+    ]
+)
+
+# Keywords describing tissues or sample origins.
+TISSUE_KEYWORDS = OrderedDict(
+    [
+        ("Blood", ["blood", "plasma", "serum", "pbmc"]),
+        ("Brain", ["brain", "cortex", "hippocampus", "neuron"]),
+        ("Liver", ["liver", "hepato"]),
+        ("Heart", ["heart", "cardiac"]),
+        ("Lung", ["lung", "pulmo"]),
+        ("Kidney", ["kidney", "renal"]),
+        ("Tumor", ["tumor", "tumour", "cancer", "carcinoma"]),
+        ("Plant", ["leaf", "root", "seed", "flower"]),
+        ("Microbial culture", ["culture", "isolate", "strain"]),
+    ]
+)
+
+LIBRARY_KEYWORDS = OrderedDict(
+    [
+        ("RNA-seq", ["rna", "mrna", "transcript", "transcriptome"]),
+        ("Single cell RNA-seq", ["scrna", "10x", "cellranger"]),
+        ("Total RNA-seq", ["totalrna", "ribo", "ribodeplete"]),
+        ("ChIP-seq", ["chip", "h3k", "h3"]),
+        ("ATAC-seq", ["atac", "tn5"]),
+        ("Whole genome sequencing", ["wgs", "genome", "illumina dna prep"]),
+        ("Whole exome sequencing", ["wes", "exome", "target"]),
+        ("Metagenomic", ["metagenome", "metagenomic", "microbiome"]),
+        ("Amplicon", ["amplicon", "16s", "its"]),
+        ("Methylation", ["methyl", "bsseq", "bisulfite"]),
+    ]
+)
+
+ENRICHMENT_KEYWORDS = OrderedDict(
+    [
+        ("Poly-A selection", ["polya", "poly-a", "mrna"]),
+        ("Ribosomal depletion", ["ribodeplete", "rrna", "ribominus"]),
+        ("Exome capture", ["exome", "sureselect", "twist", "xgen"]),
+        ("PCR amplicon", ["amplicon", "pcr"]),
+        ("Immune repertoire", ["vdj", "igh", "tcr"]),
+    ]
+)
+
+# Mapping instrument prefixes to sequencing platforms.
+INSTRUMENT_PREFIXES = OrderedDict(
+    [
+        (("NS", "NB"), "Illumina NextSeq"),
+        (("MN",), "Illumina MiniSeq"),
+        (("M0", "M1", "MI", "MS"), "Illumina MiSeq"),
+        (("A", "D", "E"), "Illumina NovaSeq"),
+        (("J",), "Illumina HiSeq X"),
+        (("K", "L"), "Illumina NovaSeq X"),
+        (("HWI", "HWUSI", "HS", "HI", "HC"), "Illumina HiSeq"),
+        (("ST", "SL", "SN"), "Illumina HiSeq 3000/4000"),
+        (("VH", "V3", "V4"), "Illumina NextSeq 2000"),
+    ]
+)
+
+# GC content heuristics for coarse organism class prediction.
+GC_CONTENT_HEURISTICS = [
+    (0.65, "High GC content (possible bacteria or GC-rich organism)"),
+    (0.50, "Moderate GC content (many microbial or plant genomes)"),
+    (0.40, "Mammalian-like GC content"),
+    (0.30, "AT-rich content (possible parasites or amplicons)"),
+]
+
+__all__ = [
+    "ADAPTER_SEQUENCES",
+    "ORGANISM_KEYWORDS",
+    "TISSUE_KEYWORDS",
+    "LIBRARY_KEYWORDS",
+    "ENRICHMENT_KEYWORDS",
+    "INSTRUMENT_PREFIXES",
+    "GC_CONTENT_HEURISTICS",
+]

--- a/src/seqmeta/inference.py
+++ b/src/seqmeta/inference.py
@@ -1,0 +1,116 @@
+"""Heuristic inference helpers."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Dict, Iterable, List, Optional
+
+from .constants import (
+    ADAPTER_SEQUENCES,
+    ENRICHMENT_KEYWORDS,
+    GC_CONTENT_HEURISTICS,
+    INSTRUMENT_PREFIXES,
+    LIBRARY_KEYWORDS,
+    ORGANISM_KEYWORDS,
+    TISSUE_KEYWORDS,
+)
+
+
+def normalize_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def find_keyword_matches(value: str, keyword_map) -> List[str]:
+    value_norm = normalize_text(value)
+    matches: List[str] = []
+    for label, keywords in keyword_map.items():
+        for keyword in keywords:
+            if keyword and keyword.lower() in value_norm:
+                matches.append(label)
+                break
+    return matches
+
+
+def infer_organisms(sample_id: str, gc_fraction: Optional[float] = None) -> Dict[str, List[str]]:
+    """Infer candidate organisms from text and GC content."""
+
+    candidates = find_keyword_matches(sample_id, ORGANISM_KEYWORDS)
+    annotations: List[str] = []
+    if gc_fraction is not None:
+        for threshold, description in GC_CONTENT_HEURISTICS:
+            if gc_fraction >= threshold:
+                annotations.append(description)
+                break
+        else:
+            annotations.append("Very AT rich content")
+    return {"candidates": candidates, "gc_annotation": annotations}
+
+
+def infer_tissues(sample_id: str) -> List[str]:
+    return find_keyword_matches(sample_id, TISSUE_KEYWORDS)
+
+
+def infer_library_types(sample_id: str, adapter_hits: Iterable[str]) -> List[str]:
+    annotations = set(find_keyword_matches(sample_id, LIBRARY_KEYWORDS))
+    for adapter_name in adapter_hits:
+        if "Nextera" in adapter_name:
+            annotations.add("Tagmentation library")
+        if "TruSeq" in adapter_name:
+            annotations.add("TruSeq-based library")
+        if "Ion Torrent" in adapter_name:
+            annotations.add("Ion Torrent library")
+    return sorted(annotations)
+
+
+def infer_enrichments(sample_id: str) -> List[str]:
+    return find_keyword_matches(sample_id, ENRICHMENT_KEYWORDS)
+
+
+def instrument_to_platform(instrument: Optional[str]) -> Optional[str]:
+    if not instrument:
+        return None
+    instrument_upper = instrument.upper()
+    for prefixes, platform in INSTRUMENT_PREFIXES.items():
+        for prefix in prefixes:
+            if instrument_upper.startswith(prefix):
+                return platform
+    return None
+
+
+def classify_index_type(index_sequences: Iterable[str]) -> str:
+    unique_indexes = {index for index in index_sequences if index}
+    if not unique_indexes:
+        return "none"
+    contains_dual = any("+" in index for index in unique_indexes)
+    if contains_dual:
+        return "dual"
+    return "single"
+
+
+def detect_umi_from_headers(headers: Iterable[str]) -> bool:
+    pattern = re.compile(r"umi[_:-]?[acgt]+", re.IGNORECASE)
+    for header in headers:
+        if pattern.search(header):
+            return True
+    return False
+
+
+def summarise_adapter_hits(hit_counter: Counter) -> List[Dict[str, float | int]]:
+    total_hits = sum(hit_counter.values())
+    summaries: List[Dict[str, float | int]] = []
+    if total_hits == 0:
+        return summaries
+    for adapter_name, count in hit_counter.most_common():
+        summaries.append(
+            {
+                "adapter": adapter_name,
+                "count": count,
+                "fraction_of_hits": count / total_hits,
+            }
+        )
+    return summaries
+
+
+def adapter_catalog() -> Dict[str, str]:
+    return dict(ADAPTER_SEQUENCES)

--- a/src/seqmeta/io.py
+++ b/src/seqmeta/io.py
@@ -1,0 +1,54 @@
+"""I/O helpers for working with FASTQ files."""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+from typing import Generator, Iterable, Iterator, Optional, Tuple
+
+
+def _is_gzip_magic(magic: bytes) -> bool:
+    return len(magic) >= 2 and magic[0] == 0x1F and magic[1] == 0x8B
+
+
+def open_maybe_gzip(path: Path):
+    """Open ``path`` transparently handling gzip-compressed files."""
+
+    with path.open("rb") as raw:
+        magic = raw.read(2)
+    if _is_gzip_magic(magic):
+        return gzip.open(path, mode="rt", encoding="utf-8", newline="\n")
+    return path.open("rt", encoding="utf-8", newline="\n")
+
+
+def read_fastq(path: Path, max_reads: Optional[int] = None) -> Iterator[Tuple[str, str, str]]:
+    """Yield ``(header, sequence, quality)`` tuples from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Location of the FASTQ file.
+    max_reads:
+        Optional cap on the number of reads to stream.
+    """
+
+    count = 0
+    with open_maybe_gzip(path) as handle:
+        while True:
+            header = handle.readline()
+            if not header:
+                break
+            sequence = handle.readline()
+            plus = handle.readline()
+            quality = handle.readline()
+            if not quality:
+                break
+            if not header.startswith("@"):
+                raise ValueError(f"Malformed FASTQ header: {header!r}")
+            yield header.rstrip("\n"), sequence.rstrip("\n"), quality.rstrip("\n")
+            count += 1
+            if max_reads is not None and count >= max_reads:
+                break
+
+
+__all__ = ["open_maybe_gzip", "read_fastq"]

--- a/src/seqmeta/samplesheet.py
+++ b/src/seqmeta/samplesheet.py
@@ -1,0 +1,77 @@
+"""Utilities for parsing simple sequencing sample sheets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class SampleEntry:
+    """Single row in the sample sheet."""
+
+    sample_id: str
+    r1_path: Path
+    r2_path: Optional[Path] = None
+
+    def validate(self) -> None:
+        """Ensure referenced FASTQ files exist."""
+
+        if not self.r1_path.exists():
+            raise FileNotFoundError(f"R1 FASTQ not found: {self.r1_path}")
+        if self.r2_path is not None and not self.r2_path.exists():
+            raise FileNotFoundError(f"R2 FASTQ not found: {self.r2_path}")
+
+
+class SampleSheet:
+    """Collection of :class:`SampleEntry` objects parsed from disk."""
+
+    def __init__(self, entries: Iterable[SampleEntry]):
+        self.entries: List[SampleEntry] = list(entries)
+
+    @classmethod
+    def from_file(cls, path: Path, validate_paths: bool = True) -> "SampleSheet":
+        """Load a sample sheet from ``path``.
+
+        Parameters
+        ----------
+        path:
+            Location of the tab separated sample sheet. The format is expected to
+            be ``sample_id`` followed by one or two FASTQ file paths. Comments
+            starting with ``#`` and blank lines are ignored.
+        validate_paths:
+            Whether to ensure that the referenced FASTQ files exist on disk.
+        """
+
+        root = path.parent
+        entries: List[SampleEntry] = []
+        with path.open("rt", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                fields = line.split("\t")
+                if len(fields) < 2:
+                    raise ValueError(
+                        f"Expected at least two tab separated columns on line {line_number}"
+                    )
+                sample_id = fields[0].strip()
+                r1_path = (root / fields[1].strip()).resolve()
+                r2_path = (root / fields[2].strip()).resolve() if len(fields) >= 3 else None
+                entry = SampleEntry(sample_id=sample_id, r1_path=r1_path, r2_path=r2_path)
+                if validate_paths:
+                    entry.validate()
+                entries.append(entry)
+        if not entries:
+            raise ValueError("Sample sheet does not contain any entries")
+        return cls(entries)
+
+    def __iter__(self):
+        return iter(self.entries)
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+
+__all__ = ["SampleEntry", "SampleSheet"]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from seqmeta.analysis import analyze_sample
+from seqmeta.samplesheet import SampleEntry
+
+from .utils import example_paired_reads, write_fastq
+
+
+def test_analyze_sample_reports_metadata(tmp_path):
+    r1_records, r2_records = example_paired_reads()
+    r1_path = write_fastq(tmp_path / "sample_human_rna_R1.fastq", r1_records)
+    r2_path = write_fastq(tmp_path / "sample_human_rna_R2.fastq.gz", r2_records)
+
+    entry = SampleEntry("Sample_Human_RNA", r1_path, r2_path)
+    metadata = analyze_sample(entry, max_reads=100)
+
+    assert metadata["paired_end"] is True
+    assert metadata["sequencing_run"]["platform"] == "Illumina NextSeq"
+    assert metadata["sequencing_run"]["index_type"] == "dual"
+    assert "Homo sapiens" in metadata["organism"]["candidates"]
+    assert "RNA-seq" in metadata["library"]["library_type_guesses"]
+    assert metadata["read_metrics"]["r1"]["read_count"] == len(r1_records)
+    assert metadata["library"]["adapter_hits"]
+    assert metadata["library"]["adapter_hit_rate"] > 0  # Should have detected adapter sequence

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from .utils import example_paired_reads, write_fastq
+
+
+def test_cli_generates_report(tmp_path):
+    r1_records, r2_records = example_paired_reads()
+    r1_path = write_fastq(tmp_path / "sample_cli_R1.fastq", r1_records)
+    r2_path = write_fastq(tmp_path / "sample_cli_R2.fastq.gz", r2_records)
+
+    sheet_path = tmp_path / "sheet.tsv"
+    sheet_path.write_text(
+        f"Sample_cli\t{Path(r1_path).name}\t{Path(r2_path).name}\n",
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "seqmeta.cli",
+        str(sheet_path),
+        "--max-reads",
+        "50",
+        "--pretty",
+    ]
+    completed = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    payload = json.loads(completed.stdout)
+
+    assert "samples" in payload
+    assert payload["samples"][0]["sample_id"] == "Sample_cli"
+    assert payload["samples"][0]["sequencing_run"]["platform"] == "Illumina NextSeq"

--- a/tests/test_samplesheet.py
+++ b/tests/test_samplesheet.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from seqmeta.samplesheet import SampleSheet
+
+from .utils import example_paired_reads, write_fastq
+
+
+def test_samplesheet_parsing(tmp_path):
+    r1_records, r2_records = example_paired_reads()
+    r1_path = write_fastq(tmp_path / "sample_R1.fastq", r1_records)
+    r2_path = write_fastq(tmp_path / "sample_R2.fastq.gz", r2_records)
+
+    sheet_path = tmp_path / "sheet.tsv"
+    sheet_path.write_text(
+        f"SampleA\t{Path(r1_path).name}\t{Path(r2_path).name}\n",
+        encoding="utf-8",
+    )
+
+    sheet = SampleSheet.from_file(sheet_path)
+    assert len(sheet) == 1
+    entry = sheet.entries[0]
+    assert entry.sample_id == "SampleA"
+    assert entry.r1_path == r1_path.resolve()
+    assert entry.r2_path == r2_path.resolve()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+from typing import Iterable, Sequence, Tuple
+
+
+def write_fastq(path: Path, records: Iterable[Tuple[str, str]]) -> Path:
+    """Write FASTQ records to ``path`` with constant high quality."""
+
+    opener = gzip.open if path.suffix.endswith(".gz") else open
+    with opener(path, "wt", encoding="utf-8") as handle:
+        for header, sequence in records:
+            quality = "I" * len(sequence)
+            handle.write(f"{header}\n{sequence}\n+\n{quality}\n")
+    return path
+
+
+def example_paired_reads() -> Tuple[Sequence[Tuple[str, str]], Sequence[Tuple[str, str]]]:
+    """Return synthetic paired-end reads with Illumina-style headers."""
+
+    r1_records = [
+        (
+            "@NS500123:45:HGTT2BGX2:1:11101:10000:100000 1:N:0:ACGTACGT+TGCATGCA",
+            "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC",
+        ),
+        (
+            "@NS500123:45:HGTT2BGX2:1:11101:10000:100001 1:N:0:ACGTACGT+TGCATGCA",
+            "GCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTAGATCGGAAGAGCACACGTCT",
+        ),
+        (
+            "@NS500123:45:HGTT2BGX2:1:11101:10000:100002 1:N:0:ACGTACGT+TGCATGCA",
+            "TTTTGGGGCCCCAAAATTTTGGGGCCCCAAAATTTTGGGGCCCCAAAATTTTGGGGCCCC",
+        ),
+    ]
+    r2_records = [
+        (
+            "@NS500123:45:HGTT2BGX2:1:11101:10000:100000 2:N:0:ACGTACGT+TGCATGCA",
+            "TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA",
+        ),
+        (
+            "@NS500123:45:HGTT2BGX2:1:11101:10000:100001 2:N:0:ACGTACGT+TGCATGCA",
+            "CGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGAT",
+        ),
+        (
+            "@NS500123:45:HGTT2BGX2:1:11101:10000:100002 2:N:0:ACGTACGT+TGCATGCA",
+            "AAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCCGGGGTTTT",
+        ),
+    ]
+    return r1_records, r2_records
+


### PR DESCRIPTION
## Summary
- add a seqmeta Python package that samples FASTQ files, collects per-read metrics, and infers sequencing metadata and warnings
- expose a CLI that parses simple TSV sample sheets and emits JSON reports describing sequencing runs and library characteristics
- provide pytest coverage for the sample sheet parser, core analyser, and CLI using synthetic FASTQ fixtures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c9278bf3888331b851446098d7d0d7